### PR TITLE
fixed value_from_attributes method when type is composite type

### DIFF
--- a/src/dynamo_json.jl
+++ b/src/dynamo_json.jl
@@ -91,7 +91,6 @@ function value_from_attributes(ty :: Type, typed_json :: Dict)
         return value_from_attributes(Dict("M" => typed_json))
     end
 
-    vals = value_from_attributes(typed_json)
-    init_vals = [vals[string(e)] for e=fieldnames(ty)]
+    init_vals = [value_from_attributes(typed_json[string(e)]) for e=fieldnames(ty)]
     ty(init_vals...)
 end

--- a/test/dynamo_json.jl
+++ b/test/dynamo_json.jl
@@ -85,6 +85,6 @@ check_round_trip(Set(["1", "2", "3"]))
 @test DynamoDB.value_from_attributes(DynamoDB.null_or_val(Dict("four" => 3, 7 => 11))) == Dict("four" => 3, "7" => 11)
 @test DynamoDB.value_from_attributes(DynamoDB.null_or_val(Foo(3, "fourty"))) == Dict("a"=>3,"b"=>"fourty")
 
-res = DynamoDB.value_from_attributes(Foo, DynamoDB.null_or_val(Foo(3, "fourty")))
+res = DynamoDB.value_from_attributes(Foo, DynamoDB.null_or_val(Foo(3, "fourty"))["M"])
 @test res.a == 3
 @test res.b == "fourty"


### PR DESCRIPTION
Dynamo returns every field in a row at the top level of the "Item" key.  For example:

```
{                          
    "Item": {
        "id": {
            "S": "001"
        },
        "int_to_update": {
            "N": "10"
        },
        "order": {
            "S": "1"
        }
    }
}
```

`value_from_attributes` previously assumed that there was only one item (probably the "M" wrapper around the map).  This fix changes `value_from_attributes` to iterate over all elements in "Item" to correctly produce the array of data needed to pass to the composite type constructor.
