### PR TITLE
allow more arbitrary nesting of indexed attributes

### DIFF
--- a/src/dynamo_dsl.jl
+++ b/src/dynamo_dsl.jl
@@ -34,9 +34,13 @@ attr(name :: AbstractString) = attribute(name)
 attr(name :: Symbol) = attribute(name)
 
 
+# short-circuit nested attribute construction
+attr(name :: DynamoReference) = name
+
+
 # a reference to dynamo sub-documents... eg "foo.bar" in {foo => {bar => 3}}
 immutable NestedDynamoAttribute <: DynamoReference
-    attrs :: Array{DynamoAttribute}
+    attrs :: Array{DynamoReference}
 end
 attribute(names...) = NestedDynamoAttribute([attr(e) for e=names])
 attr(names...) = attribute(names...)

--- a/test/dynamo_dsl.jl
+++ b/test/dynamo_dsl.jl
@@ -48,6 +48,9 @@ check_expression(attr("foo")[1], "#1[1]";
 check_expression(attr("foo", "bar")[1], "#1.#2[1]";
                  attrs = Dict("#1" => "foo", "#2" => "bar"), vals = Dict())
 
+check_expression(attr(attr("foo", "bar")[1], "baz"), "#1.#2[1].#3";
+                 attrs = Dict("#1" => "foo", "#2" => "bar", "#3" => "baz"), vals = Dict())
+
 check_expression(DynamoDB.value_or_literal(1), ":1";
                  attrs = Dict(), vals = Dict(":1" => Dict("N" => "1")))
 


### PR DESCRIPTION
e.g.,
  `#1.#2[0].#3`
which can now be created with
  `attr(attr("a","b")[0],"c")`
