### PR TITLE
make it work in 0.4 and 0.5

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.4
 AWS
 JSON
 Requests
+Compat

--- a/src/DynamoDB.jl
+++ b/src/DynamoDB.jl
@@ -2,6 +2,7 @@
 
 module DynamoDB
 
+using Compat
 using AWS
 using Requests
 import JSON

--- a/src/crypto.jl
+++ b/src/crypto.jl
@@ -4,9 +4,10 @@
 # supports the same"
 
 module Crypto
+using Compat
 
 macro c(ret_type, func, arg_types, lib)
-  local args_in = Any[ symbol(string('a',x)) for x in 1:length(arg_types.args) ]
+  local args_in = Any[ Symbol(string('a',x)) for x in 1:length(arg_types.args) ]
   quote
     $(esc(func))($(args_in...)) = ccall( ($(string(func)), $(Expr(:quote, eval(lib))) ), $ret_type, $arg_types, $(args_in...) )
   end
@@ -25,8 +26,11 @@ end
 
 typealias size_t Csize_t
 
-@unix_only const libcrypto = "libcrypto"
-@windows_only const libcrypto = Pkg.dir("WinRPM","deps","usr","$(Sys.ARCH)-w64-mingw32","sys-root","mingw","bin","libcrypto-10")
+@static if is_unix()
+    const libcrypto = "libcrypto"
+elseif is_windows()
+    const libcrypto = Pkg.dir("WinRPM","deps","usr","$(Sys.ARCH)-w64-mingw32","sys-root","mingw","bin","libcrypto-10")
+end
 
 @c Ptr{UInt8} HMAC (Ptr{EVP_MD}, Ptr{Void}, Int32, Ptr{UInt8}, size_t, Ptr{UInt8}, Ptr{UInt32}) libcrypto
 @c Ptr{UInt8} MD5 (Ptr{UInt8}, size_t, Ptr{UInt8}) libcrypto
@@ -43,13 +47,13 @@ typealias size_t Csize_t
 @c Union{} EVP_MD_CTX_destroy (Ptr{EVP_MD_CTX},) libcrypto
 
 
-hmacsha256_digest(s::AbstractString, k::Union{ASCIIString, Vector{UInt8}}) =  hmacsha_digest(s, k, EVP_sha256(), 32)
+hmacsha256_digest(s::AbstractString, k::Union{Compat.ASCIIString, Vector{UInt8}}) =  hmacsha_digest(s, k, EVP_sha256(), 32)
 export hmacsha256_digest
 
-hmacsha1_digest(s::AbstractString, k::Union{ASCIIString, Vector{UInt8}}) = hmacsha_digest(s, k, EVP_sha1(), 20)
+hmacsha1_digest(s::AbstractString, k::Union{Compat.ASCIIString, Vector{UInt8}}) = hmacsha_digest(s, k, EVP_sha1(), 20)
 export hmacsha1_digest
 
-function hmacsha_digest(s::AbstractString, k::Union{ASCIIString, Vector{UInt8}}, evp, dgst_len)
+function hmacsha_digest(s::AbstractString, k::Union{Compat.ASCIIString, Vector{UInt8}}, evp, dgst_len)
     if evp == C_NULL error("EVP_sha1() failed!") end
 
     sig = zeros(UInt8, dgst_len)

--- a/src/dynamo_dsl.jl
+++ b/src/dynamo_dsl.jl
@@ -185,7 +185,7 @@ immutable CENot <: CEBoolean
     exp
 end
 
-import Base.!
+import Base.(!)
 !(exp :: CEBoolean) = CENot(exp)
 !(exp :: DynamoAttribute) = CENot(exp)
 not(exp :: CEBoolean) = CENot(exp)

--- a/src/dynamo_json.jl
+++ b/src/dynamo_json.jl
@@ -8,11 +8,11 @@ const null_attr = Dict{AbstractString, Any}("NULL" => true)
 
 # general objects
 function attribute_value(x)
-    r = Dict{ASCIIString, Any}()
+    r = Dict{Compat.ASCIIString, Any}()
     for e=fieldnames(x)
         r[string(e)] = null_or_val(x.(e))
     end
-    Dict{ASCIIString, Any}("M" => r)
+    Dict{Compat.ASCIIString, Any}("M" => r)
 end
 
 # TODO -- binary?
@@ -29,11 +29,11 @@ attribute_value{T <: AbstractString}(x :: Set{T}) =
 # TODO -- n-dimensional arrays
 
 function attribute_value(x :: Dict)
-    dict = Dict{ASCIIString, Any}()
+    dict = Dict{Compat.ASCIIString, Any}()
     for (k,v)=x
         dict[string(k)] = null_or_val(v)
     end
-    Dict{ASCIIString, Any}("M" => dict)
+    Dict{Compat.ASCIIString, Any}("M" => dict)
 end
 
 null_or_val(x) = x == nothing ? null_attr : attribute_value(x)

--- a/src/dynamo_requests.jl
+++ b/src/dynamo_requests.jl
@@ -111,7 +111,7 @@ function dynamo_execute(env, action, json_data; current_retry=0)
     end
 
     status = resp.status
-    value = JSON.parse(bytestring(resp.data))
+    value = JSON.parse(Compat.String(copy(resp.data)))
 
     if status == 400
         if haskey(value, "__type") && ismatch(r"ProvisionedThroughputExceededException$", value["__type"])


### PR DESCRIPTION
use Symbol() instead of symbol();
use Compat.String(copy()) instead of bytestring();
use Compat.ASCIIString instead of ASCIIString;
use "import Base.(!)" instead of "import Base.!";
use e.g. "@static if is_unix()" instead of "@unix_only"
